### PR TITLE
fix(route): change route from link to endpoint directly to link index

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,15 +3,15 @@ import {
   RouterProvider,
 } from "react-router";
 import Layout from "./containers/Layout";
+import AuthPage from "./modules/authPages/AuthPage";
+import ForgetPassword from "./modules/authPages/ForgetPassword";
 import AboutUs from "./pages/AboutUs";
 import Account from "./pages/Account";
-import AuthPage from "./modules/authPages/AuthPage";
 import Cart from "./pages/Cart";
 import ConfirmOrder from "./pages/ConfirmOrder";
 import ConfirmPayment from "./pages/ConfirmPayment";
 import ContactUs from "./pages/ContactUs";
 import ContactUsDone from "./pages/ContactUsDone";
-import ForgetPassword from "./modules/authPages/ForgetPassword";
 import Home from "./pages/Home";
 import NotFound from "./pages/NotFound";
 import OrderDetail from "./pages/OrderDetail";
@@ -33,21 +33,21 @@ const router = createBrowserRouter([
       { path: "products", element: <ProductList /> },
       { path: "products/:productId", element: <ProductInfo /> },
       { path: "contact", element: <ContactUs /> },
-      { path: "contact/contactdone", element: <ContactUsDone />},
+      { path: "contact/contactdone", element: <ContactUsDone /> },
 
       {
         path: "profile",
         element: <Profile />,
         children: [
-          { path: "account", element: <Account /> },
+          { index: true, element: <Account /> },
           { path: "order-history", element: <OrderHistory /> },
           { path: "order-history/:orderId", element: <OrderDetail /> },
         ]
       },
-      { path: "profile/cart", element: <Cart />},
-      { path: "profile/cart/confirm-order", element: <ConfirmOrder />},
-      { path: "profile/cart/confirm-order/confirm-payment", element: <ConfirmPayment />},
-      { path: "profile/cart/confirm-order/confirm-payment/order-done", element: <OrderDone />},
+      { path: "/cart", element: <Cart /> },
+      { path: "/cart/confirm-order", element: <ConfirmOrder /> },
+      { path: "/cart/confirm-order/confirm-payment", element: <ConfirmPayment /> },
+      { path: "/cart/confirm-order/confirm-payment/order-done", element: <OrderDone /> },
       { path: "*", element: <NotFound /> },
     ]
   },

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,35 +1,35 @@
-import React, { useEffect, useState } from 'react'
-import { NavLink } from 'react-router'
-import ShoppingCartOutlinedIcon from '@mui/icons-material/ShoppingCartOutlined';
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
-import MenuIcon from '@mui/icons-material/Menu';
 import LogoutIcon from '@mui/icons-material/Logout';
+import MenuIcon from '@mui/icons-material/Menu';
 import ShoppingBagOutlinedIcon from '@mui/icons-material/ShoppingBagOutlined';
+import ShoppingCartOutlinedIcon from '@mui/icons-material/ShoppingCartOutlined';
+import React, { useEffect, useState } from 'react';
+import { NavLink } from 'react-router';
 
-const UserPopUp = ({isOpen = false, onClose = () => {}}) => {
+const UserPopUp = ({ isOpen = false, onClose = () => { } }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="absolute right-1 top-full mt-2 z-10">
-      <div className="absolute right-1 -top-0 w-3 h-5 bg-primary transform rotate-45 z-10"></div>
+    <div className="absolute z-10 mt-2 right-1 top-full">
+      <div className="absolute z-10 w-3 h-5 transform rotate-45 right-1 -top-0 bg-primary"></div>
 
-      <div className="relative -right-2 top-1 bg-primary rounded-md shadow-lg p-4 w-52">
+      <div className="relative p-4 rounded-md shadow-lg -right-2 top-1 bg-primary w-52">
         <ul>
-          <li className="py-2 flex items-center hover:text-accent">
+          <li className="flex items-center py-2 hover:text-accent">
             <NavLink to="profile" onClick={onClose}>
-              <AccountCircleOutlinedIcon className='mr-2'/>
+              <AccountCircleOutlinedIcon className='mr-2' />
               โปรไฟล์
             </NavLink>
           </li>
-          <li className="py-2 flex items-center hover:text-accent">
+          <li className="flex items-center py-2 hover:text-accent">
             <NavLink to="order-history" onClick={onClose}>
-              <ShoppingBagOutlinedIcon className='mr-2'/>
+              <ShoppingBagOutlinedIcon className='mr-2' />
               คำสั่งซื้อสินค้า
             </NavLink>
           </li>
-          <li className="py-2 flex items-center hover:text-accent">
+          <li className="flex items-center py-2 hover:text-accent">
             <NavLink to="/" onClick={onClose}>
-              <LogoutIcon className='mr-2'/>
+              <LogoutIcon className='mr-2' />
               ออกจากระบบ
             </NavLink>
           </li>
@@ -44,11 +44,11 @@ const SideBar = ({ isOpen, onClose }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed justify-end inset-0 z-50 flex">
+    <div className="fixed inset-0 z-50 flex justify-end">
 
       <div className="fixed inset-0 bg-transparent" onClick={onClose}></div>
 
-      <div className="relative w-64 bg-primary h-full shadow-xl flex flex-col transform transition-transform duration-600">
+      <div className="relative flex flex-col w-64 h-full transition-transform transform shadow-xl bg-primary duration-600">
         <ul className="flex-1 p-4">
           <li className='py-3 hover:text-accent'>
             <NavLink to='/' onClick={onClose} className="block">หน้าหลัก</NavLink>
@@ -129,20 +129,20 @@ const NavBar = () => {
         <div className='flex ml-4 sm:items-center'>
           <figure className='flex items-center'>
             <img className='w-6' src="/assets/logo-all_rice-black.svg" alt="All Rice Logo" />
-            <p className="logo-text ml-2">All Rice</p>
+            <p className="logo-text">All Rice</p>
           </figure>
-          <ul className='hidden ml-10 sm:flex'>
-            <li className='nav-menu'><NavLink to='/'>หน้าหลัก</NavLink></li>
-            <li className='nav-menu'><NavLink to='products'>ผลิตภัณฑ์</NavLink></li>
-            <li className='nav-menu'><NavLink to='about'>เกี่ยวกับเรา</NavLink></li>
-            <li className='nav-menu'><NavLink to='contact'>ติดต่อเรา</NavLink></li>
-          </ul>
         </div>
-        <div className='flex mr-4 items-center'>
+        <div className='hidden gap-4 sm:gap-8 sm:flex'>
+          <NavLink className='nav-menu' to='/'>หน้าหลัก</NavLink>
+          <NavLink className='nav-menu' to='products'>ผลิตภัณฑ์</NavLink>
+          <NavLink className='nav-menu' to='about'>เกี่ยวกับเรา</NavLink>
+          <NavLink className='nav-menu' to='contact'>ติดต่อเรา</NavLink>
+        </div>
+        <div className='flex items-center mr-4'>
           <NavLink to='cart'>
             <ShoppingCartOutlinedIcon />
           </NavLink>
-          <div className='profile-icon mx-6 hover:cursor-pointer relative'>
+          <div className='relative mx-6 profile-icon hover:cursor-pointer'>
             <AccountCircleOutlinedIcon onClick={toggleUserPopUp} />
             <UserPopUp isOpen={isUserPopUpOpen} onClose={closeUserPopup} />
           </div>

--- a/src/components/account/SidebarAccount.jsx
+++ b/src/components/account/SidebarAccount.jsx
@@ -1,7 +1,7 @@
-import React from 'react'
-import { NavLink } from 'react-router'
-import ShoppingBagOutlinedIcon from '@mui/icons-material/ShoppingBagOutlined';
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined';
+import ShoppingBagOutlinedIcon from '@mui/icons-material/ShoppingBagOutlined';
+import React from 'react';
+import { NavLink } from 'react-router';
 
 // ยังไม่ฟังก์ชั่น รอปรับแก้
 const SidebarAccount = () => {
@@ -10,14 +10,14 @@ const SidebarAccount = () => {
       <div className="p-4 rounded-md shadow-lg bg-primary w-52">
         <ul>
           <li className="flex items-center py-2 hover:text-accent">
-            <NavLink to="account">
-              <AccountCircleOutlinedIcon className='mr-2'/>
+            <NavLink to=".">
+              <AccountCircleOutlinedIcon className='mr-2' />
               บัญชีของฉัน
             </NavLink>
           </li>
           <li className="flex items-center py-2 hover:text-accent">
             <NavLink to="order-history">
-              <ShoppingBagOutlinedIcon className='mr-2'/>
+              <ShoppingBagOutlinedIcon className='mr-2' />
               การซื้อของฉัน
             </NavLink>
           </li>

--- a/src/index.css
+++ b/src/index.css
@@ -9,48 +9,48 @@
 */
 
 @theme inline {
-    --radius-sm: calc(var(--radius) - 4px);
-    --radius-md: calc(var(--radius) - 2px);
-    --radius-lg: var(--radius);
-    --radius-xl: calc(var(--radius) + 4px);
-    --color-background: var(--background);
-    --color-foreground: var(--foreground);
-    --color-card: var(--card);
-    --color-card-foreground: var(--card-foreground);
-    --color-popover: var(--popover);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-primary: var(--primary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-secondary: var(--secondary);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-muted: var(--muted);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-accent: var(--accent);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-destructive: var(--destructive);
-    --color-border: var(--border);
-    --color-input: var(--input);
-    --color-ring: var(--ring);
-    --color-chart-1: var(--chart-1);
-    --color-chart-2: var(--chart-2);
-    --color-chart-3: var(--chart-3);
-    --color-chart-4: var(--chart-4);
-    --color-chart-5: var(--chart-5);
-    --color-sidebar: var(--sidebar);
-    --color-sidebar-foreground: var(--sidebar-foreground);
-    --color-sidebar-primary: var(--sidebar-primary);
-    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-    --color-sidebar-accent: var(--sidebar-accent);
-    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-    --color-sidebar-border: var(--sidebar-border);
-    --color-sidebar-ring: var(--sidebar-ring);
-    --font-main: "Noto Sans Thai", sans-serif;
-    --color-slategray: #708090;
-    --color-footer: #6a7773;
-    --color-gray: #d3d3d3;
-    --color-black: #242124;
-    --facebook-blue: #1877F2;
-    /* --color-secondary: #01c9ac; */
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+  --font-main: "Noto Sans Thai", sans-serif;
+  --color-slategray: #708090;
+  --color-footer: #6a7773;
+  --color-gray: #d3d3d3;
+  --color-black: #242124;
+  --facebook-blue: #1877f2;
+  /* --color-secondary: #01c9ac; */
 }
 
 /* 
@@ -58,118 +58,116 @@
 */
 
 :root {
-    --radius: 0.625rem;
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    /* --primary: oklch(0.205 0 0); */
-    --primary: #faf9f6;
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    /* --accent: oklch(0.97 0 0); */
-    --accent: #ff9f00;
-    --accent-foreground: oklch(0.205 0 0);
-    --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.708 0 0);
-    --chart-1: oklch(0.646 0.222 41.116);
-    --chart-2: oklch(0.6 0.118 184.704);
-    --chart-3: oklch(0.398 0.07 227.392);
-    --chart-4: oklch(0.828 0.189 84.429);
-    --chart-5: oklch(0.769 0.188 70.08);
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.708 0 0);
+  --radius: 0.625rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  /* --primary: oklch(0.205 0 0); */
+  --primary: #faf9f6;
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  /* --accent: oklch(0.97 0 0); */
+  --accent: #ff9f00;
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: oklch(0.205 0 0);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
 }
 
 .dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.205 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.205 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.922 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
-    --ring: oklch(0.556 0 0);
-    --chart-1: oklch(0.488 0.243 264.376);
-    --chart-2: oklch(0.696 0.17 162.48);
-    --chart-3: oklch(0.769 0.188 70.08);
-    --chart-4: oklch(0.627 0.265 303.9);
-    --chart-5: oklch(0.645 0.246 16.439);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.488 0.243 264.376);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
-    --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.556 0 0);
 }
 
 @layer base {
-    * {
-        @apply border-border outline-ring/50;
-    }
+  * {
+    @apply border-border outline-ring/50;
+  }
 
-    body {
-        @apply bg-primary text-foreground font-main;
-    }
+  body {
+    @apply bg-primary text-foreground font-main;
+  }
 
-    footer {
-        @apply bg-footer;
-    }
+  footer {
+    @apply bg-footer;
+  }
 }
 
 @layer components {
-    .logo-text {
-        @apply ml-1 text-2xl font-bold font-main;
-    }
+  .logo-text {
+    @apply ml-2 text-xl font-bold text-nowrap font-main;
+  }
 
-    .nav-menu {
-        @apply mx-4 text-base font-bold transition-transform transform text-slategray duration-600 hover:text-accent hover:-translate-y-2;
-    }
+  .nav-menu {
+    @apply text-base font-bold transition-transform transform text-nowrap text-slategray duration-600 hover:text-accent hover:-translate-y-2;
+  }
 
-    .footer-menu {
-        @apply mb-4 text-sm transition-transform transform text-primary duration-600 hover:text-accent hover:-translate-y-1;
-    }
+  .footer-menu {
+    @apply mb-4 text-sm transition-transform transform text-primary duration-600 hover:text-accent hover:-translate-y-1;
+  }
 
-    .footer-text {
-        @apply text-sm text-gray;
-    }
+  .footer-text {
+    @apply text-sm text-gray;
+  }
 
-    .swiper {
-        width: 100%;
-        height: max-content;
-    }
+  .swiper {
+    width: 100%;
+    height: max-content;
+  }
 
-    .swiper-slide img {
-        display: block;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-    }
+  .swiper-slide img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }
-
-

--- a/src/pages/Account.jsx
+++ b/src/pages/Account.jsx
@@ -1,18 +1,19 @@
 import React from 'react'
-import AccountContainer from '../containers/AccountContainer'
 import SidebarAccount from '../components/account/SidebarAccount'
+import AccountContainer from '../containers/AccountContainer'
+
 import TabbarAccount from '../components/account/TabbarAccount'
 
 const Account = () => {
-    return (
-        <div className='flex justify-center'>
-            <div className="flex flex-col sm:flex-row sm:justify-between w-7xl">
-                <SidebarAccount />
-                <TabbarAccount />
-                <AccountContainer />
-            </div>
-        </div>
-    )
+  return (
+    <div className='flex justify-center'>
+      <div className="flex flex-col sm:flex-row sm:justify-between w-7xl">
+        <SidebarAccount />
+        <TabbarAccount />
+        <AccountContainer />
+      </div>
+    </div>
+  )
 }
 
 export default Account

--- a/src/pages/OrderDone.jsx
+++ b/src/pages/OrderDone.jsx
@@ -1,6 +1,6 @@
+import { buttonVariants } from "@/components/ui/button";
 import React from "react";
 import { useNavigate } from "react-router";
-import { buttonVariants } from "@/components/ui/button";
 
 export default function OrderSuccess() {
   const navigate = useNavigate();

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,14 +1,13 @@
 import React from 'react'
 import { Outlet } from 'react-router'
-import Account from './Account'
+
 
 const Profile = () => {
-    return (
-        <div>
-            <h1 className='text-4xl font-bold text-center'>Profile</h1>
-            <Outlet />
-        </div>
-    )
+  return (
+    <div>
+      <Outlet />
+    </div>
+  )
 }
 
 export default Profile


### PR DESCRIPTION
## 🔥 What Does This PR Do?
- [✅] Modifies routing links within the profile section (likely the sidebar) to correctly target the index route (`/profile`) instead of a specific child endpoint (like `/profile/profile`).

## 📌 Why Is This Change Needed?
- To fix an issue where a link intended to show the main profile/account view was incorrectly navigating to a non-existent or redundant nested path (e.g., `/profile/profile`).
- Ensures that clicking the primary profile link directs the user to the default view (`<Account />` component) rendered at the `/profile` index route.

## 🔄 How Did You Test This PR?
- [✅] Manually tested navigation within the profile section sidebar. Verified that clicking the "My Account" (or similar) link now correctly navigates to `/profile` and displays the Account component.
- [✅] Ensured other links within the same area (e.g., "Order History") still navigate correctly to their respective child routes (e.g., `/profile/order-history`).

## 🛠️ Any Breaking Changes?
- [❌] No: This corrects routing behavior to align with the intended structure using index routes.

## ✅ Additional Notes
- This change likely involves updating `NavLink` components within the profile page/sidebar to use `to="."` (or similar relative pathing) to target the parent's index route, leveraging React Router v6's index route feature.
