### PR TITLE
feat(similarProducts): properly shown similar in the ProductInfo page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7434,9 +7434,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.1.tgz",
-      "integrity": "sha512-/jjU3fcYNd2bwz9Q0xt5TwyiyoO8XjSEFXJY4O/lMAlkGTHWuHRAbR9Etik+lSDqMC7A7mz3UlXzgYT6Vl58sA==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.5.2.tgz",
+      "integrity": "sha512-9Rw8r199klMnlGZ8VAsV/I8WrIF6IyJ90JQUdboupx1cdkgYqwnrYjH+I/nY/7cA1X5zia4mDJqH36npP7sxGQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/src/pages/ProductInfo.jsx
+++ b/src/pages/ProductInfo.jsx
@@ -1,4 +1,4 @@
-import { Box, Container } from '@mui/material';
+import { Container } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import ProductDetails from '../containers/ProductDetails';
 
@@ -6,6 +6,7 @@ import { useParams } from 'react-router';
 import 'swiper/css';
 import 'swiper/css/pagination';
 import Carousel from '../containers/Carousel';
+import ProductCard from '../containers/ProductCard';
 import Review from '../containers/Review';
 import TabPane from '../containers/TabPane';
 import mockReviews from '../data/mockReviews';
@@ -15,14 +16,17 @@ const ProductInfo = () => {
   const { productId } = useParams();
   const [product, setProduct] = useState(null);
   const [reviewItems, setReviewItems] = useState([]);
+  const [similarProducts, setSimilarProducts] = useState([]);
 
   // mocking the fecthing data from db
   useEffect(() => {
     const numericProductId = Number(productId);
     const foundProduct = products.find((product) => product.product_id === numericProductId);
+    const sameTypeProducts = products.filter((product) => product.type === foundProduct.type);
 
     if (foundProduct) {
       setProduct(foundProduct);
+      setSimilarProducts(sameTypeProducts);
       const productReview = mockReviews.filter((review) => foundProduct.product_id === review.product_id);
       setReviewItems(productReview)
     } else {
@@ -62,12 +66,9 @@ const ProductInfo = () => {
 
       <Carousel>
         {/* ไว้รอทำ .map() */}
-        <Box className="flex rounded-lg items-center justify-center bg-gray-300 h-[229px] w-[152px]">Product Card</Box>
-        <Box className="flex rounded-lg items-center justify-center bg-gray-300 h-[229px] w-[152px]">Product Card</Box>
-        <Box className="flex rounded-lg items-center justify-center bg-gray-300 h-[229px] w-[152px]">Product Card</Box>
-        <Box className="flex rounded-lg items-center justify-center bg-gray-300 h-[229px] w-[152px]">Product Card</Box>
-        <Box className="flex rounded-lg items-center justify-center bg-gray-300 h-[229px] w-[152px]">Product Card</Box>
-        <Box className="flex rounded-lg items-center justify-center bg-gray-300 h-[229px] w-[152px]">Product Card</Box>
+        {similarProducts.map(item => (
+          <ProductCard key={item.product_id} product={item} />
+        ))}
       </Carousel>
     </Container >
   )


### PR DESCRIPTION
## 🔥 What Does This PR Do?
- [✅] Fetches and filters products based on the current product's `type` to identify similar items (`ProductInfo.jsx`).
- [✅] Adds state (`similarProducts`) to manage the list of similar products (`ProductInfo.jsx`).
- [✅] Renders the identified similar products using the existing `<ProductCard>` component within a `<Carousel>` (`ProductInfo.jsx`).

## 📌 Why Is This Change Needed?
- Enhances user experience on the Product Information page by suggesting related products within the same category.
- Aims to increase product discovery and user engagement.

## 🔄 How Did You Test This PR?
- [✅] Manually navigated to various product detail pages (`/products/:id`).
- [✅] Verified that the 'คุณอาจจะอยากลอง' section appears below the main product details and tabs.
- [✅] Confirmed that the products displayed in the carousel are of the same `type` (e.g., "ข้าวเพื่อสุขภาพ", "ข้าวขาว") as the main product shown on the page, using data from `products.js`.
- [✅] Checked the browser console for errors related to fetching or rendering similar products.

## 🛠️ Any Breaking Changes?
- [❌] No: This adds a new section using existing data structures and components.

## ✅ Additional Notes
- This PR successfully implements the logic to **identify and pass the correct data** for similar products to the `<ProductCard>` component.
- **Blockage/Dependency:** The `<ProductCard>` component itself requires updates by its designated owner (PIC) to fully utilize the provided `product` prop:
    - **Data Display:** The card needs to be modified to render key details like product name, price (handling variants if necessary), and image based on the properties available in `products.js`. Currently, it renders only partially or with placeholders.
    - **Navigation:** Functionality must be added to make each `<ProductCard>` clickable, navigating the user to the corresponding product's detail page (e.g., `/products/{item.product_id}`). This is currently missing.
